### PR TITLE
install java 8 instead of 7

### DIFF
--- a/Setup/Dockerfile
+++ b/Setup/Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get install -y software-properties-common
 #grab oracle java (auto accept licence)
 RUN add-apt-repository -y ppa:webupd8team/java
 RUN apt-get update
-RUN echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-get install -y oracle-java7-installer
+RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+RUN apt-get install -y oracle-java8-installer
 
 
 RUN apt-get install -y gobjc


### PR DESCRIPTION
This should get Java 8 instead of 7.
(Didn't test out yet with new compilebox installation.)