### PR TITLE
Docker container is now deleted on stop

### DIFF
--- a/API/DockerTimeout.sh
+++ b/API/DockerTimeout.sh
@@ -4,7 +4,7 @@ set -e
 to=$1
 shift
 
-cont=$(docker run -d "$@")
+cont=$(docker run --rm -d "$@")
 code=$(timeout "$to" docker wait "$cont" || true)
 docker kill $cont &> /dev/null
 echo -n 'status: '


### PR DESCRIPTION
I just added a `--rm` on the docker command, so now the container gets deleted once it's stopped. That way, there's no garbage left from old runs on the server.