### PR TITLE
Added support of Ubuntu 16.04 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ No two codes have access to each other’s *Docker* or files.
 	- Ubuntu 12.04 LTS
     - Ubuntu 13.10
     - Ubuntu 14.04 LTS
+    - Ubuntu 16.04 LTS
     - Linux Mint 15 
     - CentOS 6 (root required not sudo)
     

--- a/Setup/Install_16.04.sh
+++ b/Setup/Install_16.04.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+###########################
+# Docker SETUP
+###########################
+apt-get update
+apt-get install -y docker.io
+
+echo "Docker Setup complete"
+
+###########################
+# NodeJS setup
+###########################
+apt-get update
+apt-get install -y nodejs
+apt-get install -y npm
+echo "NodeJS setup Complete"
+
+###########################
+# Start Docker
+###########################
+chmod 777 ../API/DockerTimeout.sh
+chmod 777 ../API/Payload/script.sh
+chmod 777 ../API/Payload/javaRunner.sh
+chmod 777 UpdateDocker.sh
+
+systemctl restart docker
+./UpdateDocker.sh


### PR DESCRIPTION
Installation script slightly streamlined comparing to 14.04. Because
`docker.io` package now contains standard `docker` executable instead of
`docker.io`.