### PR TITLE
Added support for Rust language

### DIFF
--- a/API/compilers.js
+++ b/API/compilers.js
@@ -30,5 +30,5 @@ exports.compilerArray= [ ["python","file.py","","Python",""],
 			 ["/bin/bash","file.sh"," ","Bash",""],
 			 ["gcc ","file.m"," /usercode/a.out","Objective-C","\' -o /usercode/a.out -I/usr/include/GNUstep -L/usr/lib/GNUstep -lobjc -lgnustep-base -Wall -fconstant-string-class=NSConstantString\'"],
 			 ["/usercode/sql_runner.sh","file.sql","","MYSQL",""],
-			 ["perl","file.pl","","Perl",""] ];
-
+			 ["perl","file.pl","","Perl",""],
+			 ["\'env HOME=/opt/rust /opt/rust/.cargo/bin/rustc\'","file.rs","/usercode/a.out","Rust","\'-o /usercode/a.out\'"] ];

--- a/API/langs.js
+++ b/API/langs.js
@@ -15,6 +15,7 @@ var LANGS = {
     "Objective-C": [12,"text/x-objectivec"],
     "MySQL": [13,"text/x-sql"],
     "Perl": [14, "text/x-perl"],
+    "Rust": [15, "text/rust"],
 }
 
 
@@ -34,6 +35,7 @@ var Codes = {
     "Bash": "echo 'Hi' ",
     "Objective-C": "#include <Foundation/Foundation.h>\n\n@interface Test\n+ (const char *) classStringValue;\n@end\n\n@implementation Test\n+ (const char *) classStringValue;\n{\n    return \"Hey!\";\n}\n@end\n\nint main(void)\n{\n    printf(\"%s\\n\", [Test classStringValue]);\n    return 0;\n}",
     "Scala": "object HelloWorld {def main(args: Array[String]) = println(\"Hello\")}",
-    "VB.NET": "Imports System\n\nPublic Class Test\n\tPublic Shared Sub Main() \n    \tSystem.Console.WriteLine(\"Hello\")\n\tEnd Sub\nEnd Class"
+    "VB.NET": "Imports System\n\nPublic Class Test\n\tPublic Shared Sub Main() \n    \tSystem.Console.WriteLine(\"Hello\")\n\tEnd Sub\nEnd Class",
+    "Rust": "fn main() {\n\tprintln!(\"Hello\");\n}",
 }
 

--- a/Setup/Dockerfile
+++ b/Setup/Dockerfile
@@ -47,6 +47,11 @@ RUN apt-get install -y scala
 RUN apt-get install -y mysql-server
 RUN apt-get install -y perl
 
+RUN apt-get install -y curl
+RUN mkdir -p /opt/rust && \
+    curl https://sh.rustup.rs -sSf | HOME=/opt/rust sh -s -- --no-modify-path -y && \
+    chmod -R 777 /opt/rust
+
 RUN apt-get install -y sudo
 RUN apt-get install -y bc
 


### PR DESCRIPTION
Compiler installed through `rustup`, it is always a latest stable. `wget` could be used instead of installing `curl`, but it is used inside a remote `rustup` script. Also I used mime-type `text/rust` instead of `text/x-rust` as the rest of declarations, because it is used in official [repository](https://github.com/rust-lang/gedit-config/commit/69a3a872152a8a3e235a0411c22b02f4c657ab9a).