### PR TITLE
Pass the execution time value as the second parameter

### DIFF
--- a/API/DockerSandbox.js
+++ b/API/DockerSandbox.js
@@ -202,7 +202,7 @@ DockerSandbox.prototype.execute = function(success)
 				console.log("Time: ")
 				console.log(time)
 
-	                   	success(data,data2)
+	                   	success(data,time,data2)
 	                });
             	});
                 


### PR DESCRIPTION
Pass the execution time value as the second parameter to callback when the sandbox execution has timed out.  

This fixes an issue where a consuming application is receiving the error messages in the time property of the json result in cases where the sandbox execution times out. 