### PR TITLE
Fix NPM dependency issues and Java7 issues

### DIFF
--- a/API/app.js
+++ b/API/app.js
@@ -6,11 +6,16 @@
 */
 
 
+
+
 var express = require('express');
+var http = require('http');
 var arr = require('./compilers');
 var sandBox = require('./DockerSandbox');
-var app = express.createServer();
-var port=80;
+var bodyParser = require('body-parser');
+var app = express();
+var server = http.createServer(app);
+var port=8080;
 
 
 var ExpressBrute = require('express-brute');
@@ -21,7 +26,7 @@ var bruteforce = new ExpressBrute(store,{
 });
 
 app.use(express.static(__dirname));
-app.use(express.bodyParser());
+app.use(bodyParser());
 
 app.all('*', function(req, res, next) 
 {
@@ -71,4 +76,4 @@ app.get('/', function(req, res)
 });
 
 console.log("Listening at "+port)
-app.listen(port);
+server.listen(port);

--- a/API/package.json
+++ b/API/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "app.js",
   "dependencies": {
-    "express": "2.5.11",
+    "express": "4.*",
+    "body-parser" : "*",
     "express-brute":"*",
     "exports": "*"
   },

--- a/Setup/Dockerfile
+++ b/Setup/Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get install -y software-properties-common
 #grab oracle java (auto accept licence)
 RUN add-apt-repository -y ppa:webupd8team/java
 RUN apt-get update
-RUN echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-get install -y oracle-java7-installer
+RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+RUN apt-get install -y oracle-java8-installer
 
 
 RUN apt-get install -y gobjc


### PR DESCRIPTION
 * NPM was failing to pull in the referenced version of Express, so I updated the dependency and adjusted the code to accommodate the new Express structure. Some of this was as suggested in #32 by @JeongTaekLim
 * Also updated the default port to `8080` since `80` appears to be blocked by default on Ubuntu 16.04
 * Finally, incorporated the changes suggested by @arikrak in #6 

With these changes an a fresh Ubuntu 16.04 VM, the install scripts all work without any necessary tweaking. I haven't tested the other targeted platforms, would be happy to adjust this PR if necessary.